### PR TITLE
enhance motion handling across components

### DIFF
--- a/src/app/components/Contact/index.tsx
+++ b/src/app/components/Contact/index.tsx
@@ -1,7 +1,8 @@
 import { Mail, PhoneCall, Copy, LucideIcon } from 'lucide-react';
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import { useState } from 'react';
 import { trackContact } from '../../utils';
+import useIsDesktop from '@/hooks/useIsDesktop';
 
 export default function Contact() {
   const variants = {
@@ -9,6 +10,11 @@ export default function Contact() {
     visible: { opacity: 1, y: 0 },
   };
   const [copied, setCopied] = useState<string | null>(null);
+
+  const isDesktop = useIsDesktop();
+  const prefersReduced = useReducedMotion();
+  const reduceMotion = prefersReduced || !isDesktop;
+  const animationKey = reduceMotion ? 'no-motion' : 'with-motion';
 
   const copyToClipboard = async (text: string) => {
     try {
@@ -66,9 +72,11 @@ export default function Contact() {
       className="bg-primary relative overflow-hidden py-24 text-white"
     >
       <motion.div
-        initial="hidden"
-        whileInView="visible"
-        viewport={{ once: true }}
+        key={animationKey}
+        variants={variants}
+        initial={reduceMotion ? false : 'hidden'}
+        whileInView={reduceMotion ? undefined : 'visible'}
+        viewport={reduceMotion ? undefined : { once: true }}
         transition={{ staggerChildren: 0.15 }}
         className="mx-auto flex max-w-3xl flex-col items-center px-6 text-center"
       >

--- a/src/app/components/Hero/index.tsx
+++ b/src/app/components/Hero/index.tsx
@@ -1,5 +1,8 @@
-import { motion } from 'framer-motion';
+'use client';
+
+import { motion, useReducedMotion } from 'framer-motion';
 import Image from 'next/image';
+import useIsDesktop from '@/hooks/useIsDesktop';
 
 const container = {
   hidden: {},
@@ -7,13 +10,18 @@ const container = {
 };
 
 export default function Hero() {
+  const isDesktop = useIsDesktop();
+  const prefersReduced = useReducedMotion();
+  const reduceMotion = prefersReduced || !isDesktop;
+  const animationKey = reduceMotion ? 'no-motion' : 'with-motion';
+
   return (
     <motion.section
+      key={animationKey}
       id="inicio"
-      initial="hidden"
-      animate="show"
-      variants={container}
-      /* Full-screen hero, positions everything at the bottom */
+      initial={reduceMotion ? false : 'hidden'}
+      animate={reduceMotion ? undefined : 'show'}
+      variants={reduceMotion ? undefined : container}
       className="relative isolate flex h-screen w-full flex-col justify-start overflow-hidden pt-40 md:justify-end md:pt-0"
     >
       {/* ── Background ─────────────────────────────────────────────── */}
@@ -34,14 +42,14 @@ export default function Hero() {
       <div className="mx-auto w-full max-w-[1920px] px-6 pb-20">
         {/* Headline row */}
         <motion.div
-          variants={container}
+          variants={reduceMotion ? undefined : container}
           className="flex flex-col items-start gap-6 md:flex-row md:items-end"
         >
           {/* Brand name */}
           <motion.div
-            initial={{ y: 20, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            transition={{ duration: 0.6 }}
+            initial={reduceMotion ? false : { y: 20, opacity: 0 }}
+            animate={reduceMotion ? undefined : { y: 0, opacity: 1 }}
+            transition={{ duration: 0.3 }}
             className="relative w-[60vw] max-w-[300px] min-w-[300px]"
           >
             <Image
@@ -57,9 +65,9 @@ export default function Hero() {
 
           {/* Tag-line (wraps under larger screens) */}
           <motion.p
-            initial={{ y: 20, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            transition={{ duration: 0.6, delay: 0.15 }}
+            initial={reduceMotion ? false : { y: 20, opacity: 0 }}
+            animate={reduceMotion ? undefined : { y: 0, opacity: 1 }}
+            transition={{ duration: 0.3, delay: 0.15 }}
             className="max-w-2xl text-lg font-medium text-white md:pl-10 md:text-2xl"
           >
             Especialistas en murales que transforman espacios cotidianos en
@@ -69,9 +77,9 @@ export default function Hero() {
 
         {/* CTA buttons */}
         <motion.div
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.5 }}
+          initial={reduceMotion ? false : { opacity: 0, y: 10 }}
+          animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+          transition={{ duration: 0.3, delay: 0.5 }}
           className="absolute inset-x-0 bottom-20 z-20 mx-auto flex w-full max-w-[1920px] flex-col gap-4 px-6 md:static md:bottom-auto md:mt-12 md:flex-row"
         >
           <a

--- a/src/app/components/ProcessTimeline/index.tsx
+++ b/src/app/components/ProcessTimeline/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import Image from 'next/image';
+import useIsDesktop from '@/hooks/useIsDesktop';
 
 const steps = [
   {
@@ -27,6 +28,11 @@ const steps = [
 ];
 
 export default function ProcessTimeline() {
+  const isDesktop = useIsDesktop();
+  const prefersReducedMotion = useReducedMotion();
+  const reduceMotion = prefersReducedMotion || !isDesktop;
+  const animationKey = reduceMotion ? 'no-motion' : 'with-motion';
+
   return (
     <section id="proceso" className="relative overflow-hidden py-24 text-white">
       <div className="overflow-repeat pointer-events-none absolute inset-x-0 -top-20 -z-10 h-full">
@@ -47,22 +53,23 @@ export default function ProcessTimeline() {
         <div className="mx-auto w-fit">
           <p className="mb-6">/ Proceso</p>
           <motion.h2
-            initial={{ opacity: 0, y: 40 }}
-            whileInView={{ opacity: 1, y: 0 }}
+            key={animationKey}
+            initial={reduceMotion ? false : { opacity: 0, y: 40 }}
+            whileInView={reduceMotion ? undefined : { opacity: 1, y: 0 }}
             transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
+            viewport={reduceMotion ? undefined : { once: true }}
             className="mb-16 text-center text-3xl font-semibold md:text-6xl"
           >
             Nuestro<span className="text-primary"> proceso</span>
           </motion.h2>
         </div>
 
-        {/* timeline */}
         <motion.ul
+          key={animationKey}
           variants={{ show: { transition: { staggerChildren: 0.15 } } }}
-          initial="hidden"
-          whileInView="show"
-          viewport={{ once: true, amount: 0.2 }}
+          initial={reduceMotion ? false : 'hidden'}
+          whileInView={reduceMotion ? undefined : 'show'}
+          viewport={reduceMotion ? undefined : { once: true, amount: 0.2 }}
           className="relative before:absolute before:top-0 before:left-1/2 before:h-full before:w-px before:-translate-x-1/2 before:bg-gradient-to-b before:from-transparent before:via-white/20 before:to-transparent"
         >
           {steps.map((step, idx) => (
@@ -76,16 +83,18 @@ export default function ProcessTimeline() {
                   transition: { duration: 0.6, ease: 'easeOut' },
                 },
               }}
-              className={`group relative mb-20 flex w-full items-center ${idx % 2 === 0 ? 'flex-row-reverse' : 'flex-row'}`}
+              className={`group relative mb-20 flex w-full items-center ${
+                idx % 2 === 0 ? 'flex-row-reverse' : 'flex-row'
+              }`}
             >
-              {/* connector dot */}
               <span className="absolute top-1/2 left-1/2 z-10 flex h-5 w-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-[#2343FF] text-xs font-bold">
                 {idx + 1}
               </span>
 
-              {/* text area */}
               <div
-                className={`basis-1/2 px-4 md:px-8 ${idx % 2 === 0 ? 'text-left' : 'text-right'}`}
+                className={`basis-1/2 px-4 md:px-8 ${
+                  idx % 2 === 0 ? 'text-left' : 'text-right'
+                }`}
               >
                 <div className="rounded-md p-4">
                   <h3 className="text-lg font-medium md:text-xl">
@@ -99,7 +108,7 @@ export default function ProcessTimeline() {
 
               {/* image */}
               <motion.div
-                whileHover={{ scale: 1.03 }}
+                whileHover={reduceMotion ? undefined : { scale: 1.03 }}
                 transition={{ stiffness: 150, damping: 15 }}
                 className="basis-1/2 px-4"
               >

--- a/src/hooks/useIsDesktop.ts
+++ b/src/hooks/useIsDesktop.ts
@@ -1,0 +1,11 @@
+import { useEffect, useState } from 'react';
+
+export default function useIsDesktop(breakpoint = 768) {
+  const [isDesktop, setIsDesktop] = useState(false);
+
+  useEffect(() => {
+    setIsDesktop(window.matchMedia(`(min-width:${breakpoint}px)`).matches);
+  }, [breakpoint]);
+
+  return isDesktop;
+}


### PR DESCRIPTION
This pull request introduces a new `useIsDesktop` hook and integrates it with multiple components to improve accessibility by reducing motion for users who prefer reduced motion or are on non-desktop devices. The changes ensure animations adapt dynamically based on user preferences and device type.

### Accessibility Improvements:
* **New `useIsDesktop` Hook**: Added a custom React hook, `useIsDesktop`, to detect if the viewport width is above a specified breakpoint (default: 768px). This is used to determine whether the user is on a desktop device. (`src/hooks/useIsDesktop.ts`)

* **Dynamic Motion Reduction in Components**:
  - **`Contact` Component**: Incorporated `useIsDesktop` and `useReducedMotion` to dynamically disable or adjust animations based on user preferences and device type. Updated motion-related attributes to respect the `reduceMotion` flag. (`src/app/components/Contact/index.tsx`) [[1]](diffhunk://#diff-85eea1cfcee926ce09b8f1e8d5377bb9c380f42c5442d28e372f55e4266827b6L2-R5) [[2]](diffhunk://#diff-85eea1cfcee926ce09b8f1e8d5377bb9c380f42c5442d28e372f55e4266827b6R14-R18) [[3]](diffhunk://#diff-85eea1cfcee926ce09b8f1e8d5377bb9c380f42c5442d28e372f55e4266827b6L69-R79)
  - **`Hero` Component**: Updated animations to adapt to the `reduceMotion` flag, ensuring smoother transitions or disabling motion where necessary. (`src/app/components/Hero/index.tsx`) [[1]](diffhunk://#diff-7b65c58f6b0e0de78f917615ea4a974d44cc036195bfe4b09ea33eaee290d1c6L1-R24) [[2]](diffhunk://#diff-7b65c58f6b0e0de78f917615ea4a974d44cc036195bfe4b09ea33eaee290d1c6L37-R52) [[3]](diffhunk://#diff-7b65c58f6b0e0de78f917615ea4a974d44cc036195bfe4b09ea33eaee290d1c6L60-R70) [[4]](diffhunk://#diff-7b65c58f6b0e0de78f917615ea4a974d44cc036195bfe4b09ea33eaee290d1c6L72-R82)
  - **`ProcessTimeline` Component**: Enhanced animations to respect user preferences for reduced motion, including disabling hover effects and adjusting timeline animations. (`src/app/components/ProcessTimeline/index.tsx`) [[1]](diffhunk://#diff-aae3a0667fd331c901b340d05e77eec07ba7f1ef4fc5e49d8e6e38ec52f9fc8cL3-R5) [[2]](diffhunk://#diff-aae3a0667fd331c901b340d05e77eec07ba7f1ef4fc5e49d8e6e38ec52f9fc8cR31-R35) [[3]](diffhunk://#diff-aae3a0667fd331c901b340d05e77eec07ba7f1ef4fc5e49d8e6e38ec52f9fc8cL50-R72) [[4]](diffhunk://#diff-aae3a0667fd331c901b340d05e77eec07ba7f1ef4fc5e49d8e6e38ec52f9fc8cL79-R97) [[5]](diffhunk://#diff-aae3a0667fd331c901b340d05e77eec07ba7f1ef4fc5e49d8e6e38ec52f9fc8cL102-R111)